### PR TITLE
chore: migrate repo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,8 @@ jobs:
     needs:
       - test
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     environment:
       name: ${{ (github.ref_name == 'main') && 'staging' || format('preview-{0}', github.ref_name) }}
       url: ${{ (github.ref_name == 'main') && 'https://staging.console.web3.storage/' || steps.cloudflare_url.outputs.stdout }}

--- a/src/components/services.ts
+++ b/src/components/services.ts
@@ -5,11 +5,11 @@ import * as DID from '@ipld/dag-ucan/did'
 
 
 export const serviceURL = new URL(
-  //'https://staging.up.web3.storage'
+  // 'https://staging.up.web3.storage'
   process.env.NEXT_PUBLIC_W3UP_SERVICE_URL ?? 'https://up.web3.storage'
 )
 export const servicePrincipal = DID.parse(
-  //'did:web:staging.web3.storage'
+  // 'did:web:staging.web3.storage'
   process.env.NEXT_PUBLIC_W3UP_SERVICE_DID ?? 'did:web:web3.storage'
 )
 


### PR DESCRIPTION
Triggered a release to make sure the repo was migrated successfully.

- added a missing write perm to [GitHub - marocchino/sticky-pull-request-comment: create comment on pull request, if exists update that comment.](https://github.com/marocchino/sticky-pull-request-comment), as it seems those changes [can be set org-wide](https://github.com/organizations/w3s-project/settings/actions) but it's best to be explicit
  - more info in [Got error of \`Resource not accessible by integration\` where re-creating the same name repo · community · Discussion #60820 · GitHub](https://github.com/orgs/community/discussions/60820#discussioncomment-6445895).
